### PR TITLE
IMDB UX fallback + Sync safety (rc7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to **Movie Night Bot** will be documented in this file.
 
 
 
+
+## [1.14.3-rc7] - 2025-09-13
+### Fixed/Changed
+- IMDb display fallback: if imdb_cache is empty, fall back to stored movie.imdb_data or perform a one-time live OMDb fetch for display only. Applies to:
+  - Text post embeds and discussion thread details at creation
+  - Winner announcements (text and forum)
+  - Discord Scheduled Event updates after winner selection
+- Sync Channels safety: avoids reviving concluded sessions by only recreating missing movie posts when an active voting session exists, and only re-adding voting buttons when a session is active.
+
 ## [1.14.3-rc6] - 2025-09-13
 ### Changed
 - IMDb normalization (bot-side): all reads now pull from imdb_cache only; no fallback to movies.imdb_data. Future DB can omit imdb_data entirely.

--- a/README.md
+++ b/README.md
@@ -86,13 +86,16 @@ A comprehensive Discord bot for managing movie recommendations, voting, and orga
 - `applications.commands`
 
 ### IMDb Caching (cross-guild)
-The bot now reads IMDb data exclusively from the imdb_cache table (cache-only). If a movie is not in cache, embeds omit IMDb fields.
-- Designed to reduce OMDb usage and simplify data flow
+The bot prefers the imdb_cache table for all IMDb data. If a movie is not in cache, the bot will perform a one-time live OMDb fetch for display and attempt to cache the result when possible. This ensures posters/ratings/plots appear reliably in:
+- Movie recommendation embeds (text/forum)
+- Discussion thread details
+- Winner announcements and Discord Event updates
+- Designed to minimize OMDb usage while keeping UX complete
 - Deep purge does not clear this cache
 
 Notes:
-- Normal operations do not call OMDb directly; populate/refresh cache out-of-band as needed
-- Existing env toggles remain for cache population/maintenance flows:
+- Set `OMDB_API_KEY` to enable the live fetch fallback
+- Cache maintenance/env toggles:
   - IMDB_CACHE_ENABLED=true
   - IMDB_CACHE_TTL_DAYS=90
   - IMDB_CACHE_MAX_ROWS=10000

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movie-night-bot",
-  "version": "1.14.3-rc6",
+  "version": "1.14.3-rc7",
   "description": "Discord bot for creating movie night recommendations with voting, threads, IMDb enrichment, and forum support.",
   "main": "index.js",
   "license": "MIT",

--- a/services/movie-creation.js
+++ b/services/movie-creation.js
@@ -71,6 +71,9 @@ async function createTextMovieRecommendation(interaction, movieData, channel) {
     if (imdbId) {
       const imdb = require('./imdb');
       imdbData = await imdb.getMovieDetailsCached(imdbId);
+      if (!imdbData) {
+        try { imdbData = await imdb.getMovieDetails(imdbId); } catch (_) {}
+      }
     }
   } catch (_) {}
 
@@ -155,6 +158,9 @@ async function createForumMovieRecommendation(interaction, movieData, channel) {
     if (imdbId) {
       const imdb = require('./imdb');
       imdbData = await imdb.getMovieDetailsCached(imdbId);
+      if (!imdbData) {
+        try { imdbData = await imdb.getMovieDetails(imdbId); } catch (_) {}
+      }
     }
   } catch (_) {}
 


### PR DESCRIPTION
- Restore reliable IMDb display across posts, threads, winner announcements, and Discord Event updates by preferring imdb_cache and falling back to stored imdb_data or a one-time live OMDb fetch when cache is empty.\n- Sync Channels safety: prevent reviving ended sessions by only recreating voting posts and re-adding voting buttons when an active voting session exists.\n- Bump version to 1.14.3-rc7; update CHANGELOG and README.