### PR TITLE
Hotfix: cleanup.js syntax error (rc7)

### DIFF
--- a/services/cleanup.js
+++ b/services/cleanup.js
@@ -187,12 +187,6 @@ async function handleCleanupSync(interaction, movieChannel) {
     } catch (_) {}
     cleanedDbCount += recreatedViaHelper;
 
-          console.log(`🎬 Recreated missing post: ${movie.title}`);
-        } catch (error) {
-          console.error(`Error recreating post for ${movie.title}:`, error.message);
-        }
-      }
-    }
 
     // Step 6: Check for movies with posts but missing threads
     await recreateMissingThreads(channel, botMessages);


### PR DESCRIPTION
Remove leftover lines from previous loop in services/cleanup.js that caused 'SyntaxError: Unexpected token }' at runtime (PebbleHost).\n\nNo behavior changes beyond fixing the crash; preserves previously shipped sync safety guard.