### PR TITLE
Events: sanitize Discord Event titles (no date/time)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to **Movie Night Bot** will be documented in this file.
 
 
 
+## [1.14.3-rc11] - 2025-09-13
+### Fixed/Changed
+- Discord Events: event titles are now guaranteed to never include date/time, even if the session name contains them. Times are shown in the description using localized Discord timestamps instead.
+- Event edits use the same title sanitization path as creation.
+
+
 ## [1.14.3-rc7] - 2025-09-13
 ### Fixed/Changed
 - IMDb display fallback: if imdb_cache is empty, fall back to stored movie.imdb_data or perform a one-time live OMDb fetch for display only. Applies to:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ A comprehensive Discord bot for managing movie recommendations, voting, and orga
 
 ### 🎪 **Enhanced Session Management**
 - **Discord Event Integration**: Full event creation, updates, and RSVP functionality with channel integration
+- **Event Title Policy**: Event titles do not include date/time; localized times appear in the description using Discord timestamps (<t:…:F>/<t:…:R>).
+
 - **Timezone Support**: Configurable guild timezones with 12-hour or 24-hour time formats (e.g., 7:30 PM or 19:30) and US dates (MM/DD/YYYY)
 - **Session Descriptions**: Themed session messaging with custom descriptions in voting channels
 - **Automatic Event Updates**: Events update with winner information, IMDB details, and vote counts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movie-night-bot",
-  "version": "1.14.3-rc7",
+  "version": "1.14.3-rc11",
   "description": "Discord bot for creating movie night recommendations with voting, threads, IMDb enrichment, and forum support.",
   "main": "index.js",
   "license": "MIT",

--- a/services/discord-events.js
+++ b/services/discord-events.js
@@ -5,6 +5,19 @@
 
 const { GuildScheduledEventEntityType, GuildScheduledEventPrivacyLevel } = require('discord.js');
 
+// Ensure event titles never include date/time (Discord doesn’t localize titles)
+function buildEventTitle(sessionData) {
+  try {
+    const raw = String(sessionData?.name || 'Movie Night');
+    // Keep at most the base and optional movie title segments: "Base - Movie - Date, Time" -> "Base - Movie"
+    const chunks = raw.split(' - ').slice(0, 2);
+    const clean = chunks.join(' - ') || 'Movie Night';
+    return `🎬 ${clean}`;
+  } catch (_) {
+    return '🎬 Movie Night';
+  }
+}
+
 async function createDiscordEvent(guild, sessionData, scheduledDate) {
   if (!scheduledDate) return null;
 
@@ -83,7 +96,7 @@ async function createDiscordEvent(guild, sessionData, scheduledDate) {
 
     // Determine event type and location
     let eventConfig = {
-      name: `🎬 ${sessionData.name}`,
+      name: buildEventTitle(sessionData),
       description: enhancedDescription,
       scheduledStartTime: scheduledDate,
       scheduledEndTime: endTime,
@@ -215,7 +228,7 @@ async function updateDiscordEvent(guild, eventId, sessionData, scheduledDate) {
     }
     const startTimeStr2 = effectiveStart ? new Date(effectiveStart).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' }) : 'TBD';
     await event.edit({
-      name: `🎬 ${sessionData.name}`,
+      name: buildEventTitle(sessionData),
       description: enhancedDescription,
       scheduledStartTime: effectiveStart || event.scheduledStartAt,
       scheduledEndTime: newEnd


### PR DESCRIPTION
- Guarantee event titles never include date/time; titles are locale-agnostic\n- Show times in description via Discord timestamps (<t:...:F>/<t:...:R>)\n- Apply same sanitized title on edit path\n- Bump version to 1.14.3-rc11; update CHANGELOG and README\n\nThis addresses reports that event titles still showed times in some flows.