### PR TITLE
Bot: WS handlers for config + caps (support Phase 2b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to **Movie Night Bot** will be documented in this file.
 
 
 
+
+## [1.14.3-rc13] - 2025-09-14
+### Changed
+- WS client: add handlers `update_vote_caps` and `update_guild_config` so dashboard delegates configuration changes to the bot.
+- Emits `caps_updated` and `config_updated` events for live dashboard refresh via SSE.
+- Continues the pattern: dashboard is read-only for state; bot is single writer.
+
 ## [1.14.3-rc12] - 2025-09-13
 ### Fixed/Changed
 - Discord Events: strengthen title sanitization to robustly strip date/time words (days, months, 24h/12h times, 4-digit years). Keeps optional movie title segment only when not date-like; otherwise falls back to base title.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movie-night-bot",
-  "version": "1.14.3-rc12",
+  "version": "1.14.3-rc13",
   "description": "Discord bot for creating movie night recommendations with voting, threads, IMDb enrichment, and forum support.",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
- Add WS message handlers: update_guild_config, update_vote_caps\n- Persist config updates in DB via bot; emit caps_updated/config_updated events\n- Aligns with dashboard read-only pattern (bot is single writer)\n\nBump: 1.14.3-rc13; CHANGELOG updated.