### PR TITLE
WS: fix SyntaxError in ws-client.js (remove stray brace before catch)

### DIFF
--- a/services/ws-client.js
+++ b/services/ws-client.js
@@ -919,7 +919,6 @@ function initWebSocketClient(logger) {
             return;
           }
 
-          }
         } catch (e) {
           logger?.warn?.(`WS handler error: ${e?.message || e}`);
         }


### PR DESCRIPTION
Fixes 'Missing catch or finally after try' at services/ws-client.js:922 by removing an extra }. Verified local parse.